### PR TITLE
Different image pubtime business time

### DIFF
--- a/projects/pub-time/post.md
+++ b/projects/pub-time/post.md
@@ -1,18 +1,18 @@
 <img src="http://i.imgur.com/5CPHozf.png" width="100%" alt="We're all peacocks until we start listening to each other">
 
-Sharing awkward stories and heavy opinions builds stronger and more efficient teams. Especially when everyone learns to efface his or her own assumptions and start to listen.
+Sharing awkward stories and heavy opinions builds stronger and more efficient teams, especially when everyone learns to efface his or her own assumptions and start to listen.
 
 When you work in teams where everybody is expected to contribute from their own experience, it’s crucial to understand each other. Meetings outside the usual environment give you a different mindset. They enable you to see your colleagues for the people they are instead of who you made them out to be.
 
-That’s why earlier this year, New Atoms traveled to London for its first Offsite.
+That’s why earlier this year, New Atoms traveled to London for its first offsite.
 
-The offsite facilitated important talks about the the future of news, technology and the future in general. In the evening the conversations would transgress into talks about riding bikes into canals, our love for [Adventure Time](https://www.youtube.com/watch?v=OBYZPdu22Cg) and past romantic relationships. Most of the latter subjects unfolded in restaurants over large portions of food or in pubs with delicious beverages in hand.
+The offsite facilitated important talks about the the future of news, technology and the future in general. In the evening, the conversations would transgress into talks about riding bikes into canals, our love for [Adventure Time](https://www.youtube.com/watch?v=OBYZPdu22Cg) and past romantic relationships. Most of the latter subjects unfolded in restaurants over large portions of food or in pubs with delicious beverages in hand.
 
 <img src="https://i.imgur.com/lIEtu3A.jpg" alt="New Atoms team at FNAC" width=100% />
 
-Many times these lighter conversations gave rise to weightier topics. Topics like gender politics, the moral issues of advertising and our urge to break through conventions. It was by discussing these things that all our individual assumptions began to emerge. We noticed that when the discussion became heated most of us were saying the same, unable to actually listen to the others. The fear of being misunderstood stopped us from listening and made it impossible to learn from each other.
+Many times, these lighter conversations gave rise to weightier topics—topics like gender politics, the moral issues of advertising and our urge to break through conventions. It was by discussing these things that all our individual assumptions began to emerge. We noticed that when the discussion became heated, most of us were saying the same things with different words, unable to actually listen to the others. The fear of being misunderstood stopped us from listening and made it impossible to learn from each other.
 
-It took us quite a few attempts to realise we were all on the same page. That if one of us has a strong opinion, we should not try to fight it with our own, but that we need to understand what they are trying to convey.
+It took us quite a few attempts to realise we were all on the same page—that if someone has a strong opinion, we should not try to fight it with our own, but rather to understand what they are trying to convey.
 
 It was only by talking through these assumptions and learning how to *listen* that they began to melt away and be replaced by empathy. We were able to understand each other and see from one another's perspectives. We learned how to communicate effectively on a personal level, looking past our own baggage and assumptions.
 


### PR DESCRIPTION
**Repair**

_The image is not supportive enough of the general point of the article. Solution: improve it._

**Research**
1. Read the post again. 
2. What are the things to keep in mind when searching for an image? Used the  _Psychology of an image post_ to remind me of some guidelines:
   - _A header image should work on its own, out of its context._
   - _Images should trigger curiosity._
   - _Images should create a context._ Establish an atmosphere into which you would    like your readers to enter.
   - _Images need to tell part of the story._ Don’t go for the obvious.
   - _Appeal_ (Visual content should indicate the emotion for which it aims.) and _Retention_ (weird and counterintuitive images do well, as do conflict and suspense.)

_Keywords that pop into mind when reading the post again_
- Awkward stories
- Sensitive subjects
- Decreasing ego and listen
- Team building
- Learn to Listen
- Awkward personalities
- Pub 
- London
- Adventure Time

**Hypothesise**

If the new image supports all or most of the guidelines the image should be supportive enough of the general point of the article.

**Done**
- An image is found which meets all or most of the criteria.
- Credit is given.

**Learned**

It was very hard to find the right image with these keywords. They all were very abstract.

I learned that it's very useful to have these guidelines as a quality check for an image and it can really guide you through the thought process of finding great images.
### Note to reviewer:

Struggled a lot with this one, more difficult than I thought it would be.

Which one do you think suits the better? Please see second and third commit messages for argumentation.

The arty image of the peacock feather is maybe still too far fetched while the nightlife street image will not be one that gets noticed its own I'm afraid.
